### PR TITLE
add source command to init-openshift.sh

### DIFF
--- a/init-openshift.sh
+++ b/init-openshift.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-. init-properties.sh
+source ./init-properties.sh
 
 command -v oc >/dev/null 2>&1 || {
   echo >&2 "The oc client tools need to be installed to connect to OpenShift.";


### PR DESCRIPTION
This change makes the init-openshift.sh script more accessible on linux
bash shells by adding the "source" command and a directory relative
position to the init-provision.sh.